### PR TITLE
reinstalling the qiime2 python env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,9 +165,9 @@ COPY infra-requirements.txt /tmp/
 RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml && \
     mamba clean -afy
 
+USER root
 RUN rm /tmp/environment.yml /tmp/infra-requirements.txt
 
-USER root
 ENV PLAYWRIGHT_BROWSERS_PATH ${CONDA_DIR}
 RUN playwright install-deps
 RUN chown -Rh jovyan:jovyan /srv/conda
@@ -177,10 +177,6 @@ USER ${NB_USER}
 # DH-333
 ENV PLAYWRIGHT_BROWSERS_PATH ${CONDA_DIR}
 RUN playwright install chromium
-
-# 2024-01-13 sknapp: incompatible due to notebook 7
-# RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
-#     jupyter nbextensions_configurator enable --sys-prefix
 
 # Set CRAN mirror to rspm before we install anything
 COPY Rprofile.site /usr/lib/R/etc/Rprofile.site
@@ -201,18 +197,24 @@ RUN r /tmp/install.R && \
     rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 # install bio1b packages
+USER ${NB_USER}
 COPY bio1b-packages.bash /tmp/bio1b-packages.bash
 RUN bash /tmp/bio1b-packages.bash
+USER root
 RUN rm /tmp/bio1b-packages.bash
 
 # install ib134L packages
+USER ${NB_USER}
 COPY ib134-packages.bash /tmp/ib134-packages.bash
 RUN bash /tmp/ib134-packages.bash
+USER root
 RUN rm /tmp/ib134-packages.bash
 
 # install ccb293 packages
+USER ${NB_USER}
 COPY ccb293-packages.bash /tmp/ccb293-packages.bash
 RUN bash /tmp/ccb293-packages.bash
+USER root
 RUN rm /tmp/ccb293-packages.bash
 
 ENTRYPOINT ["tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -155,6 +155,7 @@ RUN apt-get update -qq --yes && \
 COPY install-mambaforge.bash /tmp/install-mambaforge.bash
 RUN chmod 777 /tmp/install-mambaforge.bash
 RUN /tmp/install-mambaforge.bash
+RUN rm /tmp/install-mambaforge.bash
 
 USER ${NB_USER}
 
@@ -163,6 +164,8 @@ COPY infra-requirements.txt /tmp/
 
 RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml && \
     mamba clean -afy
+
+RUN rm /tmp/environment.yml /tmp/infra-requirements.txt
 
 USER root
 ENV PLAYWRIGHT_BROWSERS_PATH ${CONDA_DIR}
@@ -200,13 +203,16 @@ RUN r /tmp/install.R && \
 # install bio1b packages
 COPY bio1b-packages.bash /tmp/bio1b-packages.bash
 RUN bash /tmp/bio1b-packages.bash
+RUN rm /tmp/bio1b-packages.bash
 
 # install ib134L packages
 COPY ib134-packages.bash /tmp/ib134-packages.bash
 RUN bash /tmp/ib134-packages.bash
+RUN rm /tmp/ib134-packages.bash
 
 # install ccb293 packages
 COPY ccb293-packages.bash /tmp/ccb293-packages.bash
 RUN bash /tmp/ccb293-packages.bash
+RUN rm /tmp/ccb293-packages.bash
 
 ENTRYPOINT ["tini", "--"]

--- a/ccb293-packages.bash
+++ b/ccb293-packages.bash
@@ -1,5 +1,8 @@
+#! /bin/bash
 # Install QIIME2 for CCB293
 # https://github.com/berkeley-dsep-infra/datahub/issues/1699
+set -ex
+
 wget https://data.qiime2.org/distro/core/qiime2-2021.8-py38-linux-conda.yml
 mamba env create -n qiime2 --file qiime2-2021.8-py38-linux-conda.yml && mamba clean -afy
 rm qiime2-2021.8-py38-linux-conda.yml


### PR DESCRIPTION
the build from last week actually passed, but the `qiime2` python env step failed:

https://github.com/berkeley-dsep-infra/biology-user-image/actions/runs/11114063973/job/30879764347#step:7:20445
```
  # >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<
  
      Traceback (most recent call last):
        File "/srv/conda/lib/python3.11/site-packages/conda/exceptions.py", line 1124, in __call__
          return func(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/srv/conda/lib/python3.11/site-packages/conda_env/cli/main.py", line 78, in do_call
          exit_code = getattr(module, func_name)(args, parser)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/srv/conda/lib/python3.11/site-packages/conda/notices/core.py", line 109, in wrapper
          return func(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/srv/conda/lib/python3.11/site-packages/conda_env/cli/main_create.py", line 154, in execute
          result[installer_type] = installer.install(prefix, pkg_specs, args, env)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/srv/conda/lib/python3.11/site-packages/mamba/mamba_env.py", line 153, in mamba_install
          transaction.fetch_extract_packages()
      RuntimeError: Download error (28) Timeout was reached [https://conda.anaconda.org/qiime2/label/r2021.8/linux-64/q2-metadata-2021.8.0-py38h32ca7bf_0.tar.bz2]
      Operation too slow. Less than 30 bytes/sec transferred the last 60 seconds
  
  `$ /srv/conda/bin/mamba create -n qiime2 --file qiime2-2021.8-py38-linux-conda.yml`
```

this PR will trigger a rebuild by adding some cleanup steps to the Dockerfile that should have been there from the beginning.